### PR TITLE
Use Port 10999 for listening as the previous value was overlapping wi…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Use Port 10999 for listening as the previous value was overlapping with the TCP ephemeral port range.
+
 ## [1.1.0] - 2023-04-20
 
 ### Added

--- a/helm/etcd-kubernetes-resources-count-exporter/values.yaml
+++ b/helm/etcd-kubernetes-resources-count-exporter/values.yaml
@@ -30,7 +30,7 @@ resource:
 registry:
   domain: docker.io
 
-listenPort: 60000
+listenPort: 10999
 
 etcd:
   endpoints: ["https://127.0.0.1:2379"]


### PR DESCRIPTION
…th the TCP ephemeral port range.

We want to stay out of the apiserver node port range

```
--service-node-port-range <a string in the form 'N1-N2'>     Default: 30000-32767
```

and linux TCP ephemeral port range

```
# cat /proc/sys/net/ipv4/ip_local_port_range 
32768   60999
```

thus changing port from 60000 to 10999

(looked up 10999 on github and couldn't find any use)