### PR TITLE
- Disable PSPs for k8s 1.25 and newer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Disable PSPs for k8s 1.25 and newer.
+
 ## [1.1.2] - 2023-04-25
 
 ### Changed

--- a/helm/etcd-kubernetes-resources-count-exporter/templates/psp.yaml
+++ b/helm/etcd-kubernetes-resources-count-exporter/templates/psp.yaml
@@ -1,3 +1,4 @@
+{{- if le (int .Capabilities.KubeVersion.Minor) 24 }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -35,3 +36,4 @@ spec:
   hostPorts:
     - min: {{ .Values.listenPort }}
       max: {{ .Values.listenPort }}
+{{- end }}


### PR DESCRIPTION
in k8s 1.25 there is no PodSecurityPolicy

this PR disables the PSP for 1.25