### PR TITLE
Use new control plane taint and label

### DIFF
--- a/helm/etcd-kubernetes-resources-count-exporter/templates/deployment.yaml
+++ b/helm/etcd-kubernetes-resources-count-exporter/templates/deployment.yaml
@@ -26,8 +26,15 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
         effect: NoSchedule
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
       nodeSelector:
+{{- if semverCompare ">=1.24.0" .Capabilities.KubeVersion.Version }}
+        node-role.kubernetes.io/control-plane: ""
+{{- else }}
         node-role.kubernetes.io/master: ""
+{{- end }}
       volumes:
       - name: {{ tpl .Values.resource.default.name  . }}-configmap
         configMap:


### PR DESCRIPTION
This PR uses the old or new control-plane label in the `nodeSelector`, depending on the Kubernetes version used.
Also adds a new toleration for the new control-plane taint.
