### PR TITLE
Update PolicyExceptions to v2beta1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed 
 
 - Set `readOnlyRootFilesystem` to true in the container security context.
+- Update Kyverno `PolicyExceptions` to `v2beta1`.
 
 ## [1.10.0] - 2024-04-01
 

--- a/helm/etcd-kubernetes-resources-count-exporter/templates/policy-exceptions.yaml
+++ b/helm/etcd-kubernetes-resources-count-exporter/templates/policy-exceptions.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.kyvernoPolicyExceptions.enabled }}
   {{- if .Capabilities.APIVersions.Has "kyverno.io/v2alpha1/PolicyException" -}}
-apiVersion: kyverno.io/v2alpha1
+apiVersion: kyverno.io/v2beta1
 kind: PolicyException
 metadata:
   name: {{ tpl .Values.resource.default.name . }}-policy-exceptions

--- a/helm/etcd-kubernetes-resources-count-exporter/templates/policy-exceptions.yaml
+++ b/helm/etcd-kubernetes-resources-count-exporter/templates/policy-exceptions.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.kyvernoPolicyExceptions.enabled }}
-  {{- if .Capabilities.APIVersions.Has "kyverno.io/v2alpha1/PolicyException" -}}
+  {{- if .Capabilities.APIVersions.Has "kyverno.io/v2beta1/PolicyException" -}}
 apiVersion: kyverno.io/v2beta1
 kind: PolicyException
 metadata:

--- a/helm/etcd-kubernetes-resources-count-exporter/templates/pss-exceptions.yaml
+++ b/helm/etcd-kubernetes-resources-count-exporter/templates/pss-exceptions.yaml
@@ -1,5 +1,5 @@
 {{- if .Capabilities.APIVersions.Has "kyverno.io/v2alpha1/PolicyException" }}
-apiVersion: kyverno.io/v2alpha1
+apiVersion: kyverno.io/v2beta1
 kind: PolicyException
 metadata:
   name: {{ tpl .Values.resource.default.name  . }}-exceptions

--- a/helm/etcd-kubernetes-resources-count-exporter/templates/pss-exceptions.yaml
+++ b/helm/etcd-kubernetes-resources-count-exporter/templates/pss-exceptions.yaml
@@ -1,4 +1,4 @@
-{{- if .Capabilities.APIVersions.Has "kyverno.io/v2alpha1/PolicyException" }}
+{{- if .Capabilities.APIVersions.Has "kyverno.io/v2beta1/PolicyException" }}
 apiVersion: kyverno.io/v2beta1
 kind: PolicyException
 metadata:


### PR DESCRIPTION
### Related issue: https://github.com/giantswarm/giantswarm/issues/30726

## Description

We need to update the PolicyExceptions apiVersion to v2beta1 as v2alpha1 is being removed in the next Kyverno release.