### PR TITLE
Set readOnlyRootFilesystem 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed 
+
+- Set `readOnlyRootFilesystem` to true in the container security context.
+
 ## [1.10.0] - 2024-04-01
 
 ### Changed 

--- a/helm/etcd-kubernetes-resources-count-exporter/values.yaml
+++ b/helm/etcd-kubernetes-resources-count-exporter/values.yaml
@@ -74,6 +74,7 @@ securityContext:
   allowPrivilegeEscalation: false
   seccompProfile:
     type: RuntimeDefault
+  readOnlyRootFilesystem: true
 
 kyvernoPolicyExceptions:
   enabled: true


### PR DESCRIPTION
This PR sets `readOnlyRootFilesystem` to true for the container.

It also removes an unused encoder parameter from the events collector `getEventFromResponse` function.

Towards: https://github.com/giantswarm/giantswarm/issues/31170